### PR TITLE
Color plot

### DIFF
--- a/TripoliApp/src/main/java/org/cirdles/tripoli/gui/constants/ConstantsTripoliApp.java
+++ b/TripoliApp/src/main/java/org/cirdles/tripoli/gui/constants/ConstantsTripoliApp.java
@@ -41,6 +41,9 @@ public enum ConstantsTripoliApp {
     //https://docs.oracle.com/javase/8/javafx/api/javafx/scene/paint/Color.html
     public static final String[] TRIPOLI_PALLETTE_FOUR = {"RED", "BLUE", "GREEN", "BLACK", "ORANGE", "INDIGO", "#35978f", "#01665e"};
 
+    // Added by Dan Johnson
+    //  aqua,beige,purple,lime-green,red,orange,cyan
+    public static final String[] TRIPOLI_PALLETTE_FIVE_A = {"#0d84a5","#f6c85f","#6f4e7c","#9ed866","#ca472f","#ffa056","#8dddd0"};
     public static final Color TRIPOLI_MOVING_SHADE = new Color(255.0 / 256.0, 182.0 / 256.0, 193.0 / 256.0, 0.5);
 
     public static @NonNls String convertColorToHex(Color color) {

--- a/TripoliApp/src/main/java/org/cirdles/tripoli/gui/constants/ConstantsTripoliApp.java
+++ b/TripoliApp/src/main/java/org/cirdles/tripoli/gui/constants/ConstantsTripoliApp.java
@@ -41,9 +41,8 @@ public enum ConstantsTripoliApp {
     //https://docs.oracle.com/javase/8/javafx/api/javafx/scene/paint/Color.html
     public static final String[] TRIPOLI_PALLETTE_FOUR = {"RED", "BLUE", "GREEN", "BLACK", "ORANGE", "INDIGO", "#35978f", "#01665e"};
 
-    // Added by Dan Johnson
     //  aqua,beige,purple,lime-green,red,orange,cyan
-    public static final String[] TRIPOLI_PALLETTE_FIVE_A = {"#0d84a5","#f6c85f","#6f4e7c","#9ed866","#ca472f","#ffa056","#8dddd0"};
+    public static final String[] TRIPOLI_PALLETTE_FIVE = {"#0d84a5","#f6c85f","#6f4e7c","#9ed866","#ca472f","#ffa056","#8dddd0"};
     public static final Color TRIPOLI_MOVING_SHADE = new Color(255.0 / 256.0, 182.0 / 256.0, 193.0 / 256.0, 0.5);
 
     public static @NonNls String convertColorToHex(Color color) {

--- a/TripoliApp/src/main/java/org/cirdles/tripoli/gui/dataViews/plots/plotsControllers/ogTripoliPlots/analysisPlots/SpeciesIntensityAnalysisPlot.java
+++ b/TripoliApp/src/main/java/org/cirdles/tripoli/gui/dataViews/plots/plotsControllers/ogTripoliPlots/analysisPlots/SpeciesIntensityAnalysisPlot.java
@@ -266,8 +266,8 @@ public class SpeciesIntensityAnalysisPlot extends AbstractPlot {
                     g2d.closePath();
                     g2d.setLineDashes(0);
                     boolean startedPlot = false;
-                    g2d.setFill(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]));
-                    g2d.setStroke(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]));
+                    g2d.setFill(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]).darker());
+                    g2d.setStroke(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]).darker());
                     for (int i = 0; i < xAxisData.length; i++) {
                         if ((yData[isotopePlotSetIndex * 4 + 2][i] != 0.0) && pointInPlot(xAxisData[i], yData[isotopePlotSetIndex * 4 + 2][i])) {
                             double dataX = mapX(xAxisData[i]);
@@ -277,7 +277,7 @@ public class SpeciesIntensityAnalysisPlot extends AbstractPlot {
                             } else {
                                 g2d.setFill(Color.RED);
                                 g2d.fillOval(dataX - 2.0, Math.abs(dataY) - 2.0, 4, 4);
-                                g2d.setFill(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]));
+                                g2d.setFill(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]).darker());
                             }
                         }
 
@@ -301,15 +301,15 @@ public class SpeciesIntensityAnalysisPlot extends AbstractPlot {
                             }
                         }
                     }
-                    g2d.setStroke(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]));
+                    g2d.setStroke(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]).darker());
                 }
                 // plot Faraday
                 if (showFaradays) {
                     g2d.closePath();
                     g2d.setLineDashes(0);
                     boolean startedPlot = false;
-                    g2d.setFill(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]).invert());
-                    g2d.setStroke(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]).invert());
+                    g2d.setFill(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]).brighter());
+                    g2d.setStroke(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]).brighter());
                     for (int i = 0; i < xAxisData.length; i++) {
                         if ((yData[isotopePlotSetIndex * 4][i] != 0.0) && pointInPlot(xAxisData[i], yData[isotopePlotSetIndex * 4][i])) {
                             double dataX = mapX(xAxisData[i]);
@@ -319,7 +319,7 @@ public class SpeciesIntensityAnalysisPlot extends AbstractPlot {
                             } else {
                                 g2d.setFill(Color.RED);
                                 g2d.fillOval(dataX - 2.0, Math.abs(dataY) - 2.0, 4, 4);
-                                g2d.setFill(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]).invert());
+                                g2d.setFill(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]).brighter());
                             }
                         }
 
@@ -343,7 +343,7 @@ public class SpeciesIntensityAnalysisPlot extends AbstractPlot {
                             }
                         }
                     }
-                    g2d.setStroke(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]).invert());
+                    g2d.setStroke(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]).brighter());
                 }
             }
         }

--- a/TripoliApp/src/main/java/org/cirdles/tripoli/gui/dataViews/plots/plotsControllers/ogTripoliPlots/analysisPlots/SpeciesIntensityAnalysisPlot.java
+++ b/TripoliApp/src/main/java/org/cirdles/tripoli/gui/dataViews/plots/plotsControllers/ogTripoliPlots/analysisPlots/SpeciesIntensityAnalysisPlot.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static java.lang.StrictMath.*;
-
+import static org.cirdles.tripoli.gui.constants.ConstantsTripoliApp.TRIPOLI_PALLETTE_FIVE;
 public class SpeciesIntensityAnalysisPlot extends AbstractPlot {
     private final SpeciesIntensityAnalysisBuilder speciesIntensityAnalysisBuilder;
     private final double[][] dfGain;
@@ -259,8 +259,6 @@ public class SpeciesIntensityAnalysisPlot extends AbstractPlot {
         g2d.setFill(dataColor.color());
         g2d.setStroke(dataColor.color());
         g2d.setLineWidth(2.0);
-
-        Color[] isotopeColors = {Color.BLUE, Color.GREEN, Color.BLACK, Color.PURPLE, Color.ORANGE};
         for (int isotopePlotSetIndex = 0; isotopePlotSetIndex < yData.length / 4; isotopePlotSetIndex++) {
             if (speciesChecked[isotopePlotSetIndex]) {
                 // plot PM
@@ -268,8 +266,8 @@ public class SpeciesIntensityAnalysisPlot extends AbstractPlot {
                     g2d.closePath();
                     g2d.setLineDashes(0);
                     boolean startedPlot = false;
-                    g2d.setFill(isotopeColors[isotopePlotSetIndex]);
-                    g2d.setStroke(isotopeColors[isotopePlotSetIndex]);
+                    g2d.setFill(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]));
+                    g2d.setStroke(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]));
                     for (int i = 0; i < xAxisData.length; i++) {
                         if ((yData[isotopePlotSetIndex * 4 + 2][i] != 0.0) && pointInPlot(xAxisData[i], yData[isotopePlotSetIndex * 4 + 2][i])) {
                             double dataX = mapX(xAxisData[i]);
@@ -279,7 +277,7 @@ public class SpeciesIntensityAnalysisPlot extends AbstractPlot {
                             } else {
                                 g2d.setFill(Color.RED);
                                 g2d.fillOval(dataX - 2.0, Math.abs(dataY) - 2.0, 4, 4);
-                                g2d.setFill(isotopeColors[isotopePlotSetIndex]);
+                                g2d.setFill(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]));
                             }
                         }
 
@@ -303,15 +301,15 @@ public class SpeciesIntensityAnalysisPlot extends AbstractPlot {
                             }
                         }
                     }
-                    g2d.setStroke(isotopeColors[isotopePlotSetIndex]);
+                    g2d.setStroke(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]));
                 }
                 // plot Faraday
                 if (showFaradays) {
                     g2d.closePath();
                     g2d.setLineDashes(0);
                     boolean startedPlot = false;
-                    g2d.setFill(isotopeColors[isotopePlotSetIndex]);
-                    g2d.setStroke(isotopeColors[isotopePlotSetIndex]);
+                    g2d.setFill(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]).invert());
+                    g2d.setStroke(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]).invert());
                     for (int i = 0; i < xAxisData.length; i++) {
                         if ((yData[isotopePlotSetIndex * 4][i] != 0.0) && pointInPlot(xAxisData[i], yData[isotopePlotSetIndex * 4][i])) {
                             double dataX = mapX(xAxisData[i]);
@@ -321,7 +319,7 @@ public class SpeciesIntensityAnalysisPlot extends AbstractPlot {
                             } else {
                                 g2d.setFill(Color.RED);
                                 g2d.fillOval(dataX - 2.0, Math.abs(dataY) - 2.0, 4, 4);
-                                g2d.setFill(isotopeColors[isotopePlotSetIndex]);
+                                g2d.setFill(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]).invert());
                             }
                         }
 
@@ -345,7 +343,7 @@ public class SpeciesIntensityAnalysisPlot extends AbstractPlot {
                             }
                         }
                     }
-                    g2d.setStroke(isotopeColors[isotopePlotSetIndex]);
+                    g2d.setStroke(Color.web(TRIPOLI_PALLETTE_FIVE[isotopePlotSetIndex]).invert());
                 }
             }
         }


### PR DESCRIPTION
Added contrasting colors to the OnPeak Intensities by Time plot.  This is what the preview looks like before the change:
![image](https://github.com/CIRDLES/Tripoli/assets/57668126/645b38b0-f7bf-4801-a3e5-68d72a284b14)
This is what it looks like after the change:
![image](https://github.com/CIRDLES/Tripoli/assets/57668126/675434f1-67c0-478c-9cdb-a573b3aaf68d)

The change was accomplished by:
1) Adding hexadecimal string constants to `ConstantsTripoliApp` in the form of a `String[]` named `TRIPOLI_PALLETTE_FIVE`
2) Replacing the arguments in the showPMs branch `GraphicsContext.setFill()` and `GraphicsContext.setStroke()` statements to use the corresponding color in `TRIPOLI_PALLETTE_FIVE`.
3) Using `Color.invert()` on the same color in the `showFaradays` branch.
