### PR TITLE
Fix ratio inversion

### DIFF
--- a/TripoliCore/src/main/java/org/cirdles/tripoli/expressions/userFunctions/UserFunction.java
+++ b/TripoliCore/src/main/java/org/cirdles/tripoli/expressions/userFunctions/UserFunction.java
@@ -147,8 +147,9 @@ public class UserFunction implements Comparable, Serializable {
     public String showCorrectName() {
         String retVal = name;
         if (inverted && treatAsIsotopicRatio) {
-            String[] nameSplit = name.split("/");
-            retVal = nameSplit[1] + "/" + nameSplit[0];
+            String[] ratioSplit = retVal.split("/", 2); // [000], [111 Words]
+            String[] nameSplit = ratioSplit[1].split(" ", 2); // [111], [Words]
+            retVal = nameSplit[0] + "/" + ratioSplit[0] + " " + nameSplit[1]; // [111/000 Words]
         }
         return retVal;
     }

--- a/TripoliCore/src/main/java/org/cirdles/tripoli/plots/analysisPlotBuilders/AnalysisBlockCyclesRecord.java
+++ b/TripoliCore/src/main/java/org/cirdles/tripoli/plots/analysisPlotBuilders/AnalysisBlockCyclesRecord.java
@@ -32,9 +32,10 @@ public record AnalysisBlockCyclesRecord(
 
     public String[] updatedTitle() {
         String[] retVal = title.clone();
-        if (isInverted && isRatio) {
-            String[] nameSplit = retVal[0].split("/");
-            retVal[0] = nameSplit[1] + "/" + nameSplit[0];
+        if (isInverted && isRatio) { // [000/111 Words]
+            String[] ratioSplit = retVal[0].split("/", 2); // [000], [111 Words]
+            String[] nameSplit = ratioSplit[1].split(" ", 1); // [111], [Words]
+            retVal[0] = nameSplit[0] + "/" + ratioSplit[0] + " " + nameSplit[1]; // [111/000 Words]
         }
         return retVal;
     }


### PR DESCRIPTION
These are the only two instances I could find for this. Pretty sure that fixes it. Limited the splits to first instances of '/' or ' '. This assumes that UF ratios always start with their isotopes in the name.