### PR TITLE
cleanup package imports

### DIFF
--- a/TripoliCore/build.gradle.kts
+++ b/TripoliCore/build.gradle.kts
@@ -27,40 +27,25 @@ plugins {
 }
 
 dependencies {
-//    implementation("de.jjohannes.gradle:extra-java-module-info:0.14")
-//    // https://mvnrepository.com/artifact/com.google.guava/guava
-//    implementation("com.google.guava:guava:31.1-jre")
-
     implementation("com.github.cirdles:commons:bc38781605")
 
     // https://mvnrepository.com/artifact/org.apache.commons/commons-math3
     implementation("org.apache.commons:commons-math3:3.6.1") // group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
+
     // https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
     implementation("org.apache.commons:commons-lang3:3.12.0")  //group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
 
     // https://mvnrepository.com/artifact/com.zaxxer/SparseBitSet
     implementation("com.zaxxer:SparseBitSet:1.2") //group: 'com.zaxxer', name: 'SparseBitSet', version: '1.2'
 
-
-    // https://mvnrepository.com/artifact/org.apache.poi/poi
-    implementation("org.apache.poi:poi:5.3.0")
-    // https://mvnrepository.com/artifact/org.apache.poi/poi-ooxml
-    implementation("org.apache.poi:poi-ooxml:5.3.0")
     // https://mvnrepository.com/artifact/net.sourceforge.jexcelapi/jxl
     implementation("net.sourceforge.jexcelapi:jxl:2.6.12")
 
-
-    // https://mvnrepository.com/artifact/gov.nist.math/jama
-    //implementation group: 'gov.nist.math', name: 'jama', version: '1.0.3'
     // modernized update: https://github.com/topobyte/jama
     implementation("com.github.topobyte:jama:master-SNAPSHOT")
 
-    // https://github.com/optimatika/ojAlgo
     // https://github.com/optimatika/ojAlgo/wiki/Optimisation-Modelling-Advice
     implementation("org.ojalgo:ojalgo:52.0.1")
-
-    implementation("com.thoughtworks.xstream:xstream:1.4.20") //group: 'com.thoughtworks.xstream', name: 'xstream', version: '1.4.19'
-
 
     // https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api
     implementation("javax.xml.bind:jaxb-api:2.4.0-b180830.0359")
@@ -68,20 +53,12 @@ dependencies {
 
     // https://mvnrepository.com/artifact/jakarta.xml.bind/jakarta.xml.bind-api
     implementation("jakarta.xml.bind:jakarta.xml.bind-api:4.0.0")
-    // https://mvnrepository.com/artifact/com.sun.xml.bind/jaxb-impl
-    //  implementation("com.sun.xml.bind:jaxb-impl:4.0.2")
-    // https://mvnrepository.com/artifact/org.eclipse.persistence/org.eclipse.persistence.moxy
-    implementation("org.eclipse.persistence:org.eclipse.persistence.moxy:4.0.1")
-
-
-    // https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core
-    implementation("org.apache.logging.log4j:log4j-core:2.20.0")
 
     // https://mvnrepository.com/artifact/org.jblas/jblas
     implementation("org.jblas:jblas:1.2.5")
 
     // https://mvnrepository.com/artifact/com.thoughtworks.xstream/xstream
-    implementation("com.thoughtworks.xstream:xstream:1.4.20")
+    implementation("com.thoughtworks.xstream:xstream:1.4.21")
 
     // https://mvnrepository.com/artifact/org.apache.commons/commons-rng-core
     implementation("org.apache.commons:commons-rng-core:1.0")
@@ -126,8 +103,6 @@ extraJavaModuleInfo {
     automaticModule("org.apache.commons:commons-rng-core", "commons.rng.core")
     automaticModule("org.apache.commons:commons-rng-simple", "commons.rng.simple")
 
-    automaticModule("org.apache.poi:poi", "poi")//org.apache.poi:poi:5.3.0
-    automaticModule("org.apache.poi:poi-ooxml", "poi.ooxml")//"org.apache.poi:poi-ooxml:5.3.0"
     automaticModule("net.sourceforge.jexcelapi:jxl", "jxl")//implementation("net.sourceforge.jexcelapi:jxl:2.6.12")
 
 

--- a/TripoliCore/src/main/java/module-info.java
+++ b/TripoliCore/src/main/java/module-info.java
@@ -16,13 +16,12 @@
 
 module Tripoli.TripoliCore {
     requires commons.bc38781605;
-    requires org.apache.poi.poi;
     requires org.jetbrains.annotations;
     requires jama;
     requires ojalgo;
     requires com.google.common;
     requires commons.math3;
-    requires org.apache.commons.lang3;
+    requires commons.lang3;
     requires jakarta.xml.bind;
     requires java.xml.bind;
     requires jblas;
@@ -30,7 +29,6 @@ module Tripoli.TripoliCore {
     requires java.logging;
     requires org.apache.commons.rng.api;
     requires org.apache.commons.rng.simple;
-    requires org.apache.poi.ooxml;
     requires jxl;
     requires org.antlr.antlr4.runtime;
     requires javafx.graphics;

--- a/TripoliCore/src/main/java/org/cirdles/tripoli/utilities/file/FileUtilities.java
+++ b/TripoliCore/src/main/java/org/cirdles/tripoli/utilities/file/FileUtilities.java
@@ -17,7 +17,7 @@
 package org.cirdles.tripoli.utilities.file;
 
 
-import org.apache.poi.util.IOUtils;
+
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -26,10 +26,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.Enumeration;
+
 import java.util.List;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 /**
  * @author James F. Bowring
@@ -70,6 +68,7 @@ public enum FileUtilities {
         return true;
     }
 
+    /*
     public static void unpackZipFile(File archive, File targetDirectory)
             throws IOException {
         ZipFile zipFile = new ZipFile(archive);
@@ -93,6 +92,7 @@ public enum FileUtilities {
             }
         }
     }
+     */
 
     public static List<Path> listRegularFiles(Path directory) throws IOException {
         List<Path> files = new ArrayList<>();


### PR DESCRIPTION
Cleaned up some of the unused imports
Removed some commented out packages (I can add these back in if you want)
Removed dupe x-stream package
Removed unused packages
POI was removed, it was only called in an unused Un-zip method.
Original jar 88.4MB
Trimmed jar 66.2 MB

I think that's as much as can be trimmed out. The next biggest package is the google guava or ojalgo but these are both utilized heavily for math stuffs