### PR TITLE
Issue #340

### DIFF
--- a/TripoliApp/src/main/java/org/cirdles/tripoli/gui/AnalysisManagerController.java
+++ b/TripoliApp/src/main/java/org/cirdles/tripoli/gui/AnalysisManagerController.java
@@ -472,6 +472,7 @@ public class AnalysisManagerController implements Initializable, AnalysisManager
 
                 if (null != analysis.getAnalysisMethod()) {
                     showTab(analysisMethodTabPane, 2, selectColumnsToPlot);
+                    showTab(analysisMethodTabPane, 3, customExpressionsTab);
                     analysisMethodTabPane.getSelectionModel().select(2);
                     populateAnalysisMethodColumnsSelectorPane();
                     processingToolBar.setVisible(false);
@@ -483,7 +484,6 @@ public class AnalysisManagerController implements Initializable, AnalysisManager
                 showTab(analysisMethodTabPane, 4, sequenceTableTab);
                 showTab(analysisMethodTabPane, 5, selectRatiosToPlotTab);
                 analysisMethodTabPane.getTabs().remove(selectColumnsToPlot);
-
                 analysisMethodTabPane.getTabs().remove(customExpressionsTab);
                 populateAnalysisMethodGridPane();
                 populateAnalysisMethodRatioBuilderPane();


### PR DESCRIPTION
Resolves issue #340.
Custom reporting depends on the list of selected analysis. Load data button did not set the new analysis as selected when finished. Null error handler was preventing this from running. Added the new analysis to the list.