### PR TITLE
Issue 393

### DIFF
--- a/TripoliCore/src/main/java/org/cirdles/tripoli/sessions/analysis/massSpectrometerModels/dataSourceProcessors/phoenix/PhoenixLiveData.java
+++ b/TripoliCore/src/main/java/org/cirdles/tripoli/sessions/analysis/massSpectrometerModels/dataSourceProcessors/phoenix/PhoenixLiveData.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.time.DateUtils;
 import org.cirdles.tripoli.constants.MassSpectrometerContextEnum;
 import org.cirdles.tripoli.expressions.userFunctions.UserFunction;
 import org.cirdles.tripoli.plots.compoundPlotBuilders.BlockCyclesBuilder;
+import org.cirdles.tripoli.plots.compoundPlotBuilders.PlotBlockCyclesRecord;
 import org.cirdles.tripoli.sessions.analysis.AnalysisInterface;
 import org.cirdles.tripoli.sessions.analysis.massSpectrometerModels.dataModels.dataLiteOne.SingleBlockRawDataLiteSetRecord;
 import org.cirdles.tripoli.sessions.analysis.massSpectrometerModels.dataModels.dataLiteOne.initializers.AllBlockInitForDataLiteOne;
@@ -197,11 +198,23 @@ public class PhoenixLiveData {
                             blockIndex,
                             massSpecExtractedData
                     );
+                    boolean[] cyclesIncluded = singleBlockRawDataLiteSetRecord.assembleCyclesIncludedForUserFunction(userFunction);
+
+                    // Preserve existing rejection state when refreshing live data
+                    PlotBlockCyclesRecord existingRecord = userFunction.getMapBlockIdToBlockCyclesRecord().get(blockIndex);
+                    boolean blockIncluded = true;
+                    if (existingRecord != null) {
+                        blockIncluded = existingRecord.blockIncluded();
+                        boolean[] existingCyclesIncluded = existingRecord.cyclesIncluded();
+                        int copyLen = Math.min(existingCyclesIncluded.length, cyclesIncluded.length);
+                        System.arraycopy(existingCyclesIncluded, 0, cyclesIncluded, 0, copyLen);
+                    }
+
                     userFunction.getMapBlockIdToBlockCyclesRecord().put(blockIndex, BlockCyclesBuilder.initializeBlockCycles(
                             blockIndex,
+                            blockIncluded,
                             true,
-                            true,
-                            singleBlockRawDataLiteSetRecord.assembleCyclesIncludedForUserFunction(userFunction),
+                            cyclesIncluded,
                             singleBlockRawDataLiteSetRecord.assembleCycleMeansForUserFunction(userFunction),
                             singleBlockRawDataLiteSetRecord.assembleCycleStdDevForUserFunction(),
                             new String[]{userFunction.getName()},

--- a/TripoliCore/src/main/java/org/cirdles/tripoli/sessions/analysis/massSpectrometerModels/dataSourceProcessors/phoenix/PhoenixLiveData.java
+++ b/TripoliCore/src/main/java/org/cirdles/tripoli/sessions/analysis/massSpectrometerModels/dataSourceProcessors/phoenix/PhoenixLiveData.java
@@ -202,12 +202,18 @@ public class PhoenixLiveData {
 
                     // Preserve existing rejection state when refreshing live data
                     PlotBlockCyclesRecord existingRecord = userFunction.getMapBlockIdToBlockCyclesRecord().get(blockIndex);
-                    boolean blockIncluded = true;
                     if (existingRecord != null) {
-                        blockIncluded = existingRecord.blockIncluded();
                         boolean[] existingCyclesIncluded = existingRecord.cyclesIncluded();
                         int copyLen = Math.min(existingCyclesIncluded.length, cyclesIncluded.length);
                         System.arraycopy(existingCyclesIncluded, 0, cyclesIncluded, 0, copyLen);
+                    }
+                    // Recompute blockIncluded: block is included if any cycle is included
+                    boolean blockIncluded = false;
+                    for (boolean included : cyclesIncluded) {
+                        if (included) {
+                            blockIncluded = true;
+                            break;
+                        }
                     }
 
                     userFunction.getMapBlockIdToBlockCyclesRecord().put(blockIndex, BlockCyclesBuilder.initializeBlockCycles(


### PR DESCRIPTION
Hey gang!

I was bored and this issue was mine anyway so here's a fix!

Adds cycle record to preserve rejections on reload. Also had to fix an issue with the plots erroring out if you rejected an entire plot. This is the only place where we would encounter issue this so it was a bit of an edge case.

### Steps to recreate:

- Pick Directory that `LiveDataStatus.txt` points at (this will be relative to your MRU analysis)
- Remove the TIMSDP so it doesnt know the analysis is finished
- Move the `LiveData` txts to a temp folder
- Start tripoli and start live data analysis
- Feed a few txt into the `LiveData` folder
- Reject all the data in a plot
- Add another plot point (load txt)